### PR TITLE
ADM remediating 30 vulnerable artifacts

### DIFF
--- a/components/camel-debezium/camel-debezium-mongodb/pom.xml
+++ b/components/camel-debezium/camel-debezium-mongodb/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-mongodb</artifactId>
-            <version>${debezium-version}</version>
+            <version>2.3.3.Final</version>
         </dependency>
 
         <!-- test -->

--- a/components/camel-git/pom.xml
+++ b/components/camel-git/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>${jgit-version}</version>
+            <version>6.6.1.202309021850-r</version>
         </dependency>
 
         <!-- testing -->

--- a/components/camel-huawei/camel-huaweicloud-dms/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-dms/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.huaweicloud.sdk</groupId>
       <artifactId>huaweicloud-sdk-core</artifactId>
-      <version>${huaweicloud-sdk-version}</version>
+      <version>3.1.53</version>
     </dependency>
 
     <!-- testing -->

--- a/components/camel-huawei/camel-huaweicloud-frs/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-frs/pom.xml
@@ -45,12 +45,12 @@
     <dependency>
       <groupId>com.huaweicloud.sdk</groupId>
       <artifactId>huaweicloud-sdk-core</artifactId>
-      <version>${huaweicloud-sdk-version}</version>
+      <version>3.1.53</version>
     </dependency>
     <dependency>
       <groupId>com.huaweicloud.sdk</groupId>
       <artifactId>huaweicloud-sdk-frs</artifactId>
-      <version>${huaweicloud-sdk-version}</version>
+      <version>3.1.53</version>
     </dependency>
 
     <dependency>

--- a/components/camel-huawei/camel-huaweicloud-functiongraph/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-functiongraph/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>com.huaweicloud.sdk</groupId>
             <artifactId>huaweicloud-sdk-functiongraph</artifactId>
-            <version>${huaweicloud-sdk-version}</version>
+            <version>3.1.53</version>
         </dependency>
 
         <dependency>

--- a/components/camel-huawei/camel-huaweicloud-iam/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-iam/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.huaweicloud.sdk</groupId>
       <artifactId>huaweicloud-sdk-iam</artifactId>
-      <version>${huaweicloud-sdk-version}</version>
+      <version>3.1.53</version>
     </dependency>
 
     <dependency>

--- a/components/camel-huawei/camel-huaweicloud-imagerecognition/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-imagerecognition/pom.xml
@@ -46,12 +46,12 @@
         <dependency>
             <groupId>com.huaweicloud.sdk</groupId>
             <artifactId>huaweicloud-sdk-core</artifactId>
-            <version>${huaweicloud-sdk-version}</version>
+            <version>3.1.53</version>
         </dependency>
         <dependency>
             <groupId>com.huaweicloud.sdk</groupId>
             <artifactId>huaweicloud-sdk-image</artifactId>
-            <version>${huaweicloud-sdk-version}</version>
+            <version>3.1.53</version>
         </dependency>
 
         <dependency>

--- a/components/camel-huawei/camel-huaweicloud-obs/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-obs/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>${squareup-okhttp-version}</version>
+      <version>4.0.0-alpha01</version>
     </dependency>
 
     <dependency>

--- a/components/camel-huawei/camel-huaweicloud-smn/pom.xml
+++ b/components/camel-huawei/camel-huaweicloud-smn/pom.xml
@@ -54,12 +54,12 @@
         <dependency>
             <groupId>com.huaweicloud.sdk</groupId>
             <artifactId>huaweicloud-sdk-core</artifactId>
-            <version>${huaweicloud-sdk-version}</version>
+            <version>3.1.53</version>
         </dependency>
         <dependency>
             <groupId>com.huaweicloud.sdk</groupId>
             <artifactId>huaweicloud-sdk-smn</artifactId>
-            <version>${huaweicloud-sdk-version}</version>
+            <version>3.1.53</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/components/camel-kubernetes/pom.xml
+++ b/components/camel-kubernetes/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>${squareup-okhttp-version}</version>
+            <version>4.0.0-alpha01</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/components/camel-slack/pom.xml
+++ b/components/camel-slack/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>${squareup-okhttp-version}</version>
+            <version>4.0.0-alpha01</version>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
## Vulnerabilities: [Remediation Run Detect Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.iad.amaaaaaa5f5ialyagoe5zbvhu2gdrt2aglhavud5gy6cvmrkknlto34gb4kq/runs/ocid1.admremediationrun.oc1.iad.amaaaaaa5f5ialyat2kcavaoj6s7dctdpmxonwtoipelqpy2jtqvqvrx2q5q/stages/DETECT)

* org.apache.camel.maven:camel-debezium-maven-plugin:4.1.0-SNAPSHOT
  * io.debezium:debezium-embedded:2.3.2.Final
    * org.eclipse.jetty:jetty-http:9.4.48.v20220622
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-server:9.4.48.v20220622
      * CVE-2023-26048
      * CVE-2023-26049
    * org.eclipse.jetty:jetty-servlets:9.4.48.v20220622
      * CVE-2023-36479
    * org.xerial.snappy:snappy-java:1.1.8.4
      * CVE-2023-34453
      * CVE-2023-34454
      * CVE-2023-34455
      * CVE-2023-43642
* org.apache.camel.maven:camel-salesforce-maven-plugin:4.1.0-SNAPSHOT
  * org.apache.camel:camel-salesforce-codegen:4.1.0-SNAPSHOT
    * org.apache.commons:commons-compress:1.22
      * CVE-2023-42503
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
* org.apache.camel:apache-camel:4.1.0-SNAPSHOT
  * org.apache.camel:camel-allcomponents:4.1.0-SNAPSHOT
    * com.google.flatbuffers:flatbuffers-java:1.12.0
      * CVE-2020-35864
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * junit:junit:4.11
      * CVE-2020-15250
    * net.lingala.zip4j:zip4j:2.11.2
      * CVE-2023-22899
    * org.apache.httpcomponents:httpclient:4.5.10
      * CVE-2020-13956
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r
      * CVE-2023-4759
    * org.java-websocket:Java-WebSocket:1.3.8
      * CVE-2020-11050
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-catalog-console:4.1.0-SNAPSHOT
    * com.google.flatbuffers:flatbuffers-java:1.12.0
      * CVE-2020-35864
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * junit:junit:4.11
      * CVE-2020-15250
    * net.lingala.zip4j:zip4j:2.11.2
      * CVE-2023-22899
    * org.apache.httpcomponents:httpclient:4.5.10
      * CVE-2020-13956
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r
      * CVE-2023-4759
    * org.java-websocket:Java-WebSocket:1.3.8
      * CVE-2020-11050
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-catalog-lucene:4.1.0-SNAPSHOT
    * com.google.flatbuffers:flatbuffers-java:1.12.0
      * CVE-2020-35864
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * junit:junit:4.11
      * CVE-2020-15250
    * net.lingala.zip4j:zip4j:2.11.2
      * CVE-2023-22899
    * org.apache.httpcomponents:httpclient:4.5.10
      * CVE-2020-13956
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r
      * CVE-2023-4759
    * org.java-websocket:Java-WebSocket:1.3.8
      * CVE-2020-11050
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-catalog-maven-grape:4.1.0-SNAPSHOT
    * com.google.flatbuffers:flatbuffers-java:1.12.0
      * CVE-2020-35864
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * junit:junit:4.11
      * CVE-2020-15250
    * net.lingala.zip4j:zip4j:2.11.2
      * CVE-2023-22899
    * org.apache.httpcomponents:httpclient:4.5.10
      * CVE-2020-13956
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r
      * CVE-2023-4759
    * org.java-websocket:Java-WebSocket:1.3.8
      * CVE-2020-11050
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-catalog-maven:4.1.0-SNAPSHOT
    * com.google.flatbuffers:flatbuffers-java:1.12.0
      * CVE-2020-35864
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * junit:junit:4.11
      * CVE-2020-15250
    * net.lingala.zip4j:zip4j:2.11.2
      * CVE-2023-22899
    * org.apache.httpcomponents:httpclient:4.5.10
      * CVE-2020-13956
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r
      * CVE-2023-4759
    * org.java-websocket:Java-WebSocket:1.3.8
      * CVE-2020-11050
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-route-parser:4.1.0-SNAPSHOT
    * com.google.flatbuffers:flatbuffers-java:1.12.0
      * CVE-2020-35864
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * junit:junit:4.11
      * CVE-2020-15250
    * net.lingala.zip4j:zip4j:2.11.2
      * CVE-2023-22899
    * org.apache.httpcomponents:httpclient:4.5.10
      * CVE-2020-13956
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r
      * CVE-2023-4759
    * org.java-websocket:Java-WebSocket:1.3.8
      * CVE-2020-11050
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
* org.apache.camel:bom-generator-maven-plugin:4.1.0-SNAPSHOT
  * org.apache.maven.shared:maven-artifact-transfer:0.13.1
    * org.apache.maven.shared:maven-shared-utils:3.1.0
      * CVE-2022-29599
* org.apache.camel:camel-allcomponents:4.1.0-SNAPSHOT
  * org.apache.camel:camel-amqp:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-arangodb:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-avro-rpc-jetty:4.1.0-SNAPSHOT
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-avro-rpc-spi:4.1.0-SNAPSHOT
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-avro-rpc:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-avro:4.1.0-SNAPSHOT
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-aws-cloudtrail:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws-secrets-manager:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-athena:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-cw:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-ddb:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-ec2:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-ecs:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-eks:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-eventbridge:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-iam:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-kinesis:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-kms:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-lambda:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-mq:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-msk:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-s3:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-ses:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-sns:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-sqs:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-step-functions:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-sts:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-timestream:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-aws2-translate:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-azure-cosmosdb:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-azure-eventhubs:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-azure-files:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-azure-key-vault:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-azure-servicebus:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-azure-storage-blob:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-azure-storage-datalake:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-azure-storage-queue:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-box-api:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-box:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-cassandraql:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-coap:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-cometd:4.1.0-SNAPSHOT
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
  * org.apache.camel:camel-consul:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-datasonnet:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-debezium-common:4.1.0-SNAPSHOT
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-debezium-db2:4.1.0-SNAPSHOT
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-debezium-mongodb:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-debezium-mysql:4.1.0-SNAPSHOT
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-debezium-oracle:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * junit:junit:4.11
      * CVE-2020-15250
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-debezium-postgres:4.1.0-SNAPSHOT
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-debezium-sqlserver:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-dhis2-api:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-dhis2:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-docker:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-drill:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-elytron:4.1.0-SNAPSHOT
    * junit:junit:4.11
      * CVE-2020-15250
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-etcd3:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-fhir:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-flink:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-fop:4.1.0-SNAPSHOT
    * junit:junit:4.11
      * CVE-2020-15250
  * org.apache.camel:camel-geocoder:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-git:4.1.0-SNAPSHOT
    * org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r
      * CVE-2023-4759
  * org.apache.camel:camel-google-bigquery:4.1.0-SNAPSHOT
    * com.google.flatbuffers:flatbuffers-java:1.12.0
      * CVE-2020-35864
  * org.apache.camel:camel-grape:4.1.0-SNAPSHOT
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-groovy:4.1.0-SNAPSHOT
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-grpc:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-hashicorp-vault:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-hdfs:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-hl7:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-huaweicloud-dms:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-huaweicloud-frs:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-huaweicloud-functiongraph:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-huaweicloud-iam:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-huaweicloud-imagerecognition:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-huaweicloud-obs:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-huaweicloud-smn:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-iec60870:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-infinispan-embedded:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * junit:junit:4.11
      * CVE-2020-15250
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-infinispan:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-influxdb2:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-influxdb:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-jackson-avro:4.1.0-SNAPSHOT
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-jetty:4.1.0-SNAPSHOT
    * org.eclipse.jetty:jetty-http:11.0.15
      * CVE-2023-40167
    * org.eclipse.jetty:jetty-servlets:11.0.15
      * CVE-2023-36479
  * org.apache.camel:camel-jgroups-raft:4.1.0-SNAPSHOT
    * junit:junit:4.11
      * CVE-2020-15250
  * org.apache.camel:camel-jgroups:4.1.0-SNAPSHOT
    * junit:junit:4.11
      * CVE-2020-15250
  * org.apache.camel:camel-jpa:4.1.0-SNAPSHOT
    * junit:junit:4.11
      * CVE-2020-15250
  * org.apache.camel:camel-jsonapi:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-kafka:4.1.0-SNAPSHOT
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-knative-http:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-kubernetes:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.jetbrains.kotlin:kotlin-stdlib:1.4.10
      * CVE-2020-29582
      * CVE-2022-24329
  * org.apache.camel:camel-leveldb:4.1.0-SNAPSHOT
    * org.xerial.snappy:snappy-java:1.1.10.1
      * CVE-2023-43642
  * org.apache.camel:camel-lumberjack:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-mail-microsoft-oauth:4.1.0-SNAPSHOT
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
    * org.bouncycastle:bcprov-jdk15on:1.57
      * CVE-2017-13098
      * CVE-2018-1000180
      * CVE-2018-1000613
      * CVE-2020-15522
  * org.apache.camel:camel-micrometer:4.1.0-SNAPSHOT
    * com.squareup.okio:okio:2.10.0
      * CVE-2023-3635
    * org.bouncycastle:bcpkix-jdk15on:1.57
      * CVE-2017-13098
...

## Dependencies upgraded: [Remediation Run Recommend Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.iad.amaaaaaa5f5ialyagoe5zbvhu2gdrt2aglhavud5gy6cvmrkknlto34gb4kq/runs/ocid1.admremediationrun.oc1.iad.amaaaaaa5f5ialyat2kcavaoj6s7dctdpmxonwtoipelqpy2jtqvqvrx2q5q/stages/RECOMMEND)

* com.huaweicloud.sdk:huaweicloud-sdk-core:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-core:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-frs:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-frs:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-functiongraph:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-functiongraph:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-iam:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-iam:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-image:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-image:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-smn:3.1.52 -> 3.1.53
* com.huaweicloud.sdk:huaweicloud-sdk-smn:3.1.52 -> 3.1.53
* com.squareup.okhttp3:okhttp:3.12.12 -> 4.0.0-alpha01
* com.squareup.okhttp3:okhttp:3.14.9 -> 4.0.0-alpha01
* com.squareup.okhttp3:okhttp:3.14.9 -> 4.0.0-alpha01
* com.squareup.okhttp3:okhttp:3.14.9 -> 4.0.0-alpha01
* io.debezium:debezium-connector-mongodb:2.3.2.Final -> 2.3.3.Final
* io.debezium:debezium-connector-mongodb:2.3.2.Final -> 2.3.3.Final
* io.debezium:debezium-connector-mongodb:2.3.2.Final -> 2.3.3.Final
* io.micrometer:micrometer-core:1.11.3 -> 1.11.4
* io.micrometer:micrometer-core:1.11.3 -> 1.11.4
* io.micrometer:micrometer-core:1.11.3 -> 1.11.4
* io.micrometer:micrometer-core:1.11.3 -> 1.11.4
* io.micrometer:micrometer-core:1.11.3 -> 1.11.4
* io.micrometer:micrometer-core:1.11.3 -> 1.11.4
* io.micrometer:micrometer-core:1.11.3 -> 1.11.4
* io.micrometer:micrometer-tracing:1.1.4 -> 1.1.5
* io.micrometer:micrometer-tracing:1.1.4 -> 1.1.5
* io.micrometer:micrometer-tracing:1.1.4 -> 1.1.5
* org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r -> 6.6.1.202309021850-r

Auto-merge is disabled.